### PR TITLE
Add admin email config and page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# 관리자의 이메일 주소를 설정합니다. Firebase Remote Config의 'admin_email' 값을 사용하려면 비워두세요.
+NEXT_PUBLIC_ADMIN_EMAIL=

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useAdminEmail } from '@/hooks/use-admin-email';
+import { useMemo } from 'react';
+
+export default function AdminPage() {
+  const { user } = useAuth();
+  const adminEmail = useAdminEmail();
+  const isAdmin = useMemo(() => user?.email === adminEmail, [user?.email, adminEmail]);
+
+  if (!isAdmin) {
+    return <div className="mt-10 text-center">접근 권한이 없습니다.</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">어드민 페이지</h1>
+      <p>관리자만 볼 수 있는 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -20,8 +20,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
+import { useAdminEmail } from '@/hooks/use-admin-email';
 
-const ADMIN_EMAIL = 'jirrral@gmail.com';
 const STATUS_OPTIONS_KOREAN = ["처리 전", "처리 중", "보류 중", "처리 완료", "종료됨", "정보 필요"];
 const ITEMS_PER_PAGE = 20;
 
@@ -38,6 +38,7 @@ interface FlattenedDataRow extends SubmittedInquiryDataRow {
 
 export default function DashboardPage() {
   const { user } = useAuth();
+  const adminEmail = useAdminEmail();
   const { toast } = useToast();
   const [submittedInquiries, setSubmittedInquiries] = useState<SubmittedInquiry[]>([]);
   const [isLoadingInquiries, setIsLoadingInquiries] = useState(true);
@@ -57,7 +58,7 @@ export default function DashboardPage() {
   const [bulkStatus, setBulkStatus] = useState<string>('');
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
 
-  const isAdmin = useMemo(() => user?.email === ADMIN_EMAIL, [user?.email]);
+  const isAdmin = useMemo(() => user?.email === adminEmail, [user?.email, adminEmail]);
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/layout/UserNav.tsx
+++ b/src/components/layout/UserNav.tsx
@@ -23,9 +23,14 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { LogOut } from "lucide-react";
 import { UserCircleIcon } from '@/components/icons/UserCircleIcon';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { useAdminEmail } from '@/hooks/use-admin-email';
 
 export function UserNav() {
   const { user, logout, isAuthenticated } = useAuth();
+  const adminEmail = useAdminEmail();
+  const isAdmin = useMemo(() => user?.email === adminEmail, [user?.email, adminEmail]);
 
   if (!isAuthenticated || !user) {
     return null;
@@ -53,6 +58,11 @@ export function UserNav() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        {isAdmin && (
+          <DropdownMenuItem>
+            <Link href="/admin">어드민 페이지</Link>
+          </DropdownMenuItem>
+        )}
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <DropdownMenuItem onSelect={(event) => event.preventDefault()}>

--- a/src/hooks/use-admin-email.ts
+++ b/src/hooks/use-admin-email.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+import { fetchAdminEmail } from '@/lib/adminEmail';
+
+export function useAdminEmail() {
+  const [adminEmail, setAdminEmail] = useState<string | undefined>(
+    process.env.NEXT_PUBLIC_ADMIN_EMAIL
+  );
+
+  useEffect(() => {
+    if (!adminEmail) {
+      fetchAdminEmail().then((email) => {
+        if (email) {
+          setAdminEmail(email);
+        }
+      });
+    }
+  }, [adminEmail]);
+
+  return adminEmail;
+}

--- a/src/lib/adminEmail.ts
+++ b/src/lib/adminEmail.ts
@@ -1,0 +1,27 @@
+import { getRemoteConfig, fetchAndActivate, getValue } from 'firebase/remote-config';
+import { app } from './firebase';
+
+let cachedEmail: string | undefined;
+
+export async function fetchAdminEmail(): Promise<string | undefined> {
+  if (cachedEmail) {
+    return cachedEmail;
+  }
+
+  if (process.env.NEXT_PUBLIC_ADMIN_EMAIL) {
+    cachedEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
+    return cachedEmail;
+  }
+
+  try {
+    const remoteConfig = getRemoteConfig(app);
+    remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
+    await fetchAndActivate(remoteConfig);
+    const email = getValue(remoteConfig, 'admin_email').asString();
+    cachedEmail = email;
+    return email;
+  } catch (error) {
+    console.error('Failed to load admin email from Remote Config', error);
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- load admin email from environment or Firebase Remote Config
- share admin email in dashboard and new admin page
- show admin page link in user dropdown for admins
- document `NEXT_PUBLIC_ADMIN_EMAIL` in `.env.example`
- allow `.env.example` in git

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_683f9cd37f7c8320b78f0224719d5779